### PR TITLE
String concatenation does not add '\0', causing an error during OTA running

### DIFF
--- a/sdk_src/utils/json_token.c
+++ b/sdk_src/utils/json_token.c
@@ -68,6 +68,7 @@ char *LITE_json_value_of(char *key, char *src)
         return NULL;
     }
     HAL_Snprintf(ret, value_len + 1, "%s", value);
+    ret[value_len] = '\0';
     return ret;
 }
 


### PR DESCRIPTION
Fixed the error in the return format when compiling and running in MinGW environment because '\0' was not added in the process of splicing strings.