### PR TITLE
fix: use size of destination as third argument of strncpy()

### DIFF
--- a/sdk_src/services/gateway/gateway_common.c
+++ b/sdk_src/services/gateway/gateway_common.c
@@ -749,7 +749,7 @@ int subdev_bind_hmac_sha1_cal(DeviceInfo *pDevInfo, char *signout, int max_signl
         return ret;
     }
 #else
-    strncpy(key, pDevInfo->device_secret, strlen(pDevInfo->device_secret));
+    strncpy(key, pDevInfo->device_secret, BIND_SIGN_KEY_SIZE);
 #endif
 
     /*cal hmac sha1*/


### PR DESCRIPTION
Calling 'strncpy' with the size of the source buffer as the third argument may result in a buffer overflow.