### PR TITLE
fix: fix wrong type of arguments to formatting function

### DIFF
--- a/sdk_src/internal_inc/gateway_common.h
+++ b/sdk_src/internal_inc/gateway_common.h
@@ -49,7 +49,7 @@
 /* The format of bind cmd payload */
 #define GATEWAY_PAYLOAD_OP_FMT                                                    \
     "{\"type\":\"%s\",\"payload\":{\"devices\":[{\"product_id\":\"%s\","          \
-    "\"device_name\":\"%s\",\"signature\":\"%s\",\"random\":%d,\"timestamp\":%d," \
+    "\"device_name\":\"%s\",\"signature\":\"%s\",\"random\":%d,\"timestamp\":%ld," \
     "\"signmethod\":\"%s\",\"authtype\":\"%s\"}]}}"
 
 /* Subdevice    seesion status */

--- a/sdk_src/internal_inc/qcloud_iot_http.h
+++ b/sdk_src/internal_inc/qcloud_iot_http.h
@@ -23,7 +23,7 @@ extern "C" {
 #define QCLOUD_HTTP_HEADER_FORMAT \
     "Accept: %s*/*\r\n"           \
     "X-TC-Algorithm: %s\r\n"      \
-    "X-TC-Timestamp: %d\r\n"      \
+    "X-TC-Timestamp: %ld\r\n"      \
     "X-TC-Nonce: %d\r\n"          \
     "X-TC-Signature: %s\r\n"
 

--- a/sdk_src/protocol/websocket/utils_websocket_client.c
+++ b/sdk_src/protocol/websocket/utils_websocket_client.c
@@ -146,7 +146,7 @@ static int _websocket_genmask_callback(wslay_event_context_ptr ctx, uint8_t *buf
 {
     srand((unsigned)time(NULL));
     int nonce = rand() % 99999999999 + 10000;
-    HAL_Snprintf((char *)buf, len, "%0*d", len - 1, nonce);
+    HAL_Snprintf((char *)buf, len, "%0*d", (int)(len - 1), nonce);
     return 0;
 }
 


### PR DESCRIPTION
- The type of timestamp is long. Thus it should be printed with '%ld'.
- For format string "%0*d", the width specified should be of type int.